### PR TITLE
Cálculo gastos de envío a partir de dirección

### DIFF
--- a/webapp/src/api/api.ts
+++ b/webapp/src/api/api.ts
@@ -31,13 +31,13 @@ export async function addPedido(products:ProductoParaPedido[] ,user_id:String|un
 }
 
 
-export async function getGastosEnvio():Promise<number>{
+export async function getGastosEnvio(direccion: string):Promise<number>{
     const apiEndPoint= process.env.REACT_APP_API_URI || 'http://localhost:5000'
 
     let response = await fetch(apiEndPoint+'/pedido/gastosEnvio', {
         method: 'POST',
         headers: {'Content-Type':'application/json'},
-        body: JSON.stringify({"direcc":"Oviedo"})
+        body: JSON.stringify({"direcc":direccion})
     });
     if (response.status===200)
         return response.json();

--- a/webapp/src/components/pago/pago.css
+++ b/webapp/src/components/pago/pago.css
@@ -2,6 +2,7 @@
     margin-left: 5%;
     display: grid;
     grid-template-columns: auto auto;
+    margin-bottom: 4%;
 }
 
 .productosPedido {
@@ -38,4 +39,9 @@
     justify-content: right;
     justify-self: right;
     margin-right: 20%;
+}
+
+.buttonDireccion {
+    margin-left: 3%;
+    vertical-align: middle;
 }

--- a/webapp/src/pages/pagoPage/VentanaPago.tsx
+++ b/webapp/src/pages/pagoPage/VentanaPago.tsx
@@ -41,13 +41,23 @@ function VentanaPago(): JSX.Element {
 
     let carritoData: string = localStorage.getItem("carrito")!;
     var carrito = getCarrito(carritoData);
+
     const [gastosEnv,setGastosEnv]=useState<number>();
-    const cogerGastos=async ()=>{
-        setGastosEnv(await getGastosEnvio());
+
+    const calcularGastos = async() => {
+        if (direccion === undefined) {
+            setGastosEnv(0);
+        } else {
+            if (direccion.length > 0) {
+                setGastosEnv(await getGastosEnvio(direccion));
+            }
+        }
     }
+
     useEffect(()=>{
-        cogerGastos();
+        calcularGastos();
     },[]);
+
     function calcularTotalFinal(){
         if(gastosEnv){
             return (gastosEnv+calcularTotal(carrito)).toFixed(2);
@@ -55,10 +65,14 @@ function VentanaPago(): JSX.Element {
             return calcularTotal(carrito).toFixed(2);
         }
     }
+
     const calcularTotal = (productos: ProductoParaPedido[]) =>
         productos.reduce((accum: number, p) => accum + p.cantidad * p.precio, 0);
 
+
     let totalProductos: number = calcularTotal(carrito);
+
+    const [direccion, setDireccion] = useState<string>();
 
     // @ts-ignore
     // @ts-ignore
@@ -72,7 +86,7 @@ function VentanaPago(): JSX.Element {
                         {
                             carrito.map((prod: ProductoParaPedido) => {
                                 return (
-                                    <ProductoPedido nombre={prod.nombre} imagen={prod.imagen} precio={prod.precio}
+                                    <ProductoPedido key={prod.nombre} nombre={prod.nombre} imagen={prod.imagen} precio={prod.precio}
                                         cantidad={prod.cantidad} />
                                 )
                             })
@@ -92,18 +106,27 @@ function VentanaPago(): JSX.Element {
                             <TextField  className='textField'
                                         required
                                         name="direccion"
-                                        label="password"
+                                        label="Dirección"
                                         variant="outlined"
-
+                                        onChange={e => { 
+                                            setDireccion(e.target.value);
+                                        }}
                                         sx={{ my: 2 }}
                             />
-
+                            <Button
+                                size="small"
+                                disableElevation
+                                variant="contained"
+                                onClick={() => {
+                                    calcularGastos();
+                                }}
+                            >
+                                Confirmar dirección
+                            </Button>
                             <Typography variant="body1">
-                                {"Gastos de envío: "+gastosEnv}
+                                {"Gastos de envío: " + gastosEnv}
                             </Typography>
-                            <br></br>
                             <Typography variant="h5">
-
                                 {"Total a pagar: " + calcularTotalFinal() + " €"}
                             </Typography>
                         </CardContent>
@@ -112,7 +135,8 @@ function VentanaPago(): JSX.Element {
                                 size="large"
                                 disableElevation
                                 variant="contained"
-                                onClick={() => {addPedido(carrito,"dadad",Number.parseFloat(calcularTotalFinal()));
+                                onClick={() => {
+                                    addPedido(carrito,"dadad",Number.parseFloat(calcularTotalFinal()));
                                     navigate("/pago/finalizado");
                                 }}
                             >

--- a/webapp/src/pages/pagoPage/VentanaPago.tsx
+++ b/webapp/src/pages/pagoPage/VentanaPago.tsx
@@ -100,9 +100,6 @@ function VentanaPago(): JSX.Element {
                                 {"Detalles"}
                             </Typography>
                             <br></br>
-                            <Typography variant="body1">
-                                {"Total del pedido: " + totalProductos.toFixed(2) + " €"}
-                            </Typography>
                             <TextField  className='textField'
                                         required
                                         name="direccion"
@@ -114,6 +111,7 @@ function VentanaPago(): JSX.Element {
                                         sx={{ my: 2 }}
                             />
                             <Button
+                                className="buttonDireccion"
                                 size="small"
                                 disableElevation
                                 variant="contained"
@@ -124,7 +122,10 @@ function VentanaPago(): JSX.Element {
                                 Confirmar dirección
                             </Button>
                             <Typography variant="body1">
-                                {"Gastos de envío: " + gastosEnv}
+                                {"Total del pedido: " + totalProductos.toFixed(2) + " €"}
+                            </Typography>
+                            <Typography variant="body1">
+                                {"Gastos de envío: " + gastosEnv + " €"}
                             </Typography>
                             <Typography variant="h5">
                                 {"Total a pagar: " + calcularTotalFinal() + " €"}


### PR DESCRIPTION
En la ventana de pago se añade un campo de texto en el que escribir la dirección, y los gastos de envío se actualizan con el valor correspondiente